### PR TITLE
[Feature] 채팅방 입장 시 주문 id도 함께 전송

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -5,11 +5,13 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:socket_io_client/socket_io_client.dart' as IO;
 
 class ChatScreen extends ConsumerStatefulWidget {
+  final int orderId;
   final String targetName;
   final int targetId;
 
   const ChatScreen({
     super.key,
+    required this.orderId,
     required this.targetName,
     required this.targetId,
   });
@@ -57,7 +59,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     socket.onConnect((_) {
       print('✅ Socket connected');
-      socket.emit('joinRoom', {'userId': myId, 'targetId': widget.targetId});
+      socket.emit('joinRoom', {'orderId': widget.orderId, 'userId': myId, 'targetId': widget.targetId});
     });
 
     socket.on('previousMessages', (data) {

--- a/lib/screens/customer/customer_orderList_screen.dart
+++ b/lib/screens/customer/customer_orderList_screen.dart
@@ -154,6 +154,7 @@ class _CustomerOrderListScreenState extends State<CustomerOrderListScreen> {
                                   context.push(
                                     '/chat',
                                     extra: {
+                                      'orderId': order['orderId'],
                                       'targetId': market['userId'],
                                       'targetName': market['name'],
                                     },

--- a/lib/screens/merchant/merchant_orderList_screen.dart
+++ b/lib/screens/merchant/merchant_orderList_screen.dart
@@ -147,6 +147,7 @@ class _MerchantOrderListScreenState extends State<MerchantOrderListScreen> {
                                   context.push(
                                     '/chat',
                                     extra: {
+                                      'orderId': order['orderId'],
                                       'targetId': customer['id'],
                                       'targetName': customer['name'],
                                     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅 화면에서 주문 ID를 함께 전달받아 사용할 수 있도록 개선되었습니다.

* **버그 수정**
  * 채팅 진입 시 주문 정보가 누락되지 않도록 주문 ID가 정상적으로 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->